### PR TITLE
Add Makefile with brew-dump target

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,8 +1,5 @@
 README.md
 CLAUDE.md
-LICENSE
-setup.sh
 Brewfile
 stylua.toml
-chezmoi-migration-plan.md
 Makefile

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -5,3 +5,4 @@ setup.sh
 Brewfile
 stylua.toml
 chezmoi-migration-plan.md
+Makefile

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: brew-dump
+
+brew-dump: ## Update Brewfile with currently installed packages
+	brew bundle dump --force --file="$(CURDIR)/Brewfile"


### PR DESCRIPTION
## Summary
- `make brew-dump` で Brewfile を更新できるようにした
- Makefile を `.chezmoiignore` に追加（ホームには配置しない）

## Usage
```bash
chezmoi cd
make brew-dump
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)