### PR TITLE
Replace automatic brew bundle with Makefile target

### DIFF
--- a/.chezmoiscripts/run_onchange_after_brew-bundle.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_brew-bundle.sh.tmpl
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-# Brewfile hash: {{ include "Brewfile" | sha256sum }}
-brew bundle --file="{{ .chezmoi.sourceDir }}/Brewfile"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: brew-dump
+.PHONY: brew-dump brew-install
 
 brew-dump: ## Update Brewfile with currently installed packages
 	brew bundle dump --force --file="$(CURDIR)/Brewfile"
+
+brew-install: ## Install packages from Brewfile
+	brew bundle --file="$(CURDIR)/Brewfile"


### PR DESCRIPTION
## Summary
- Remove `run_onchange_after_brew-bundle.sh.tmpl` to prevent `chezmoi apply` from blocking on new machines
- Add `make brew-install` target for explicit brew bundle execution

## Test plan
- [ ] `chezmoi apply -v` completes without running brew bundle
- [ ] `make brew-install` installs packages from Brewfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)