### PR TITLE
[tig] commit/branch 操作とコピー系のキーバインドを追加

### DIFF
--- a/dot_config/wezterm/wezterm.lua
+++ b/dot_config/wezterm/wezterm.lua
@@ -14,6 +14,15 @@ end)
 
 local config = {
   adjust_window_size_when_changing_font_size = false,
+  -- tig 等でのコピー成功を画面フラッシュで通知する。音は煩いので無効化し視覚のみ
+  audible_bell = "Disabled",
+  visual_bell = {
+    fade_in_function = "EaseIn",
+    fade_in_duration_ms = 75,
+    fade_out_function = "EaseOut",
+    fade_out_duration_ms = 75,
+    target = "CursorColor",
+  },
   cell_width = 1.1,
   color_scheme = "Hybrid (terminal.sexy)",
   colors = {

--- a/dot_config/wezterm/wezterm.lua
+++ b/dot_config/wezterm/wezterm.lua
@@ -14,15 +14,6 @@ end)
 
 local config = {
   adjust_window_size_when_changing_font_size = false,
-  -- tig 等でのコピー成功を画面フラッシュで通知する。音は煩いので無効化し視覚のみ
-  audible_bell = "Disabled",
-  visual_bell = {
-    fade_in_function = "EaseIn",
-    fade_in_duration_ms = 75,
-    fade_out_function = "EaseOut",
-    fade_out_duration_ms = 75,
-    target = "CursorColor",
-  },
   cell_width = 1.1,
   color_scheme = "Hybrid (terminal.sexy)",
   colors = {

--- a/dot_tigrc
+++ b/dot_tigrc
@@ -3,7 +3,7 @@ set vertical-split = no
 
 # generic view
 bind generic S none
-bind generic ` @bash -c "echo -n '%(commit)' | pbcopy" # copy selected commit hash
+bind generic ` +sh -c "printf %s '%(commit)' | pbcopy && echo 'Copied commit: %(commit)'" # copy selected commit hash (main 等ではステータスラインに表示。refs は reload で消えるため refs 用に別バインド)
 
 # main view: 主にcommitに対しての操作をする
 # -I: rebaseの "-i" オプションから

--- a/dot_tigrc
+++ b/dot_tigrc
@@ -3,7 +3,7 @@ set vertical-split = no
 
 # generic view
 bind generic S none
-bind generic ` @bash -c "echo -n '%(commit)' | pbcopy" # copy selected commit hash
+bind generic ` +sh -c "printf %s '%(commit)' | pbcopy && echo 'Copied commit: %(commit)'" # copy selected commit hash
 
 # main view: 主にcommitに対しての操作をする
 # -I: rebaseの "-i" オプションから
@@ -41,6 +41,7 @@ bind refs <Ctrl-s> ?git sync
 bind refs p ?git pull %(remote) %(repo:head)
 bind refs M ?git merge %(branch)
 bind refs + ?git rebase %(branch)
+bind refs ` +sh -c "printf %s '%(branch)' | pbcopy && echo 'Copied branch: %(branch)'" # copy selected branch name
 
 # stash view
 # - S: stashのS. このためにgenericに割り当てられた `S` を無効化した

--- a/dot_tigrc
+++ b/dot_tigrc
@@ -41,7 +41,7 @@ bind refs <Ctrl-s> ?git sync
 bind refs p ?git pull %(remote) %(repo:head)
 bind refs M ?git merge %(branch)
 bind refs + ?git rebase %(branch)
-bind refs ` +sh -c "printf %s '%(branch)' | pbcopy && echo 'Copied branch: %(branch)'" # copy selected branch name
+bind refs ` @sh -c "printf %s '%(branch)' | pbcopy && printf '\\a' > /dev/tty" # copy selected branch name (refs は reload で status 表示が消えるため画面フラッシュで通知)
 
 # stash view
 # - S: stashのS. このためにgenericに割り当てられた `S` を無効化した

--- a/dot_tigrc
+++ b/dot_tigrc
@@ -16,8 +16,8 @@ bind main I ?git rebase -i %(commit)
 bind main F ?git commit --fixup %(commit)
 bind main C ?git cherry-pick %(commit)
 bind main K ?git rebase --onto %(commit)^ %(commit)
-bind main <LessThan>    ?git reset --soft %(commit)
-bind main <GreaterThan> ?git reset --hard %(commit)
+bind main <LessThan> ?git reset --soft %(commit)
+bind main >          ?git reset --hard %(commit)
 
 # status view: 作業中のメインview. 最も多く利用する
 bind status P ?git push %(remote) %(repo:head)

--- a/dot_tigrc
+++ b/dot_tigrc
@@ -3,7 +3,7 @@ set vertical-split = no
 
 # generic view
 bind generic S none
-bind generic ` +sh -c "printf %s '%(commit)' | pbcopy && echo 'Copied commit: %(commit)'" # copy selected commit hash
+bind generic ` @bash -c "echo -n '%(commit)' | pbcopy" # copy selected commit hash
 
 # main view: 主にcommitに対しての操作をする
 # -I: rebaseの "-i" オプションから
@@ -41,7 +41,7 @@ bind refs <Ctrl-s> ?git sync
 bind refs p ?git pull %(remote) %(repo:head)
 bind refs M ?git merge %(branch)
 bind refs + ?git rebase %(branch)
-bind refs ` @sh -c "printf %s '%(branch)' | pbcopy && printf '\\a' > /dev/tty" # copy selected branch name (refs は reload で status 表示が消えるため画面フラッシュで通知)
+bind refs ` @bash -c "echo -n '%(branch)' | pbcopy" # copy selected branch name
 
 # stash view
 # - S: stashのS. このためにgenericに割り当てられた `S` を無効化した

--- a/dot_tigrc
+++ b/dot_tigrc
@@ -8,14 +8,22 @@ bind generic ` @bash -c "echo -n '%(commit)' | pbcopy" # copy selected commit ha
 # main view: 主にcommitに対しての操作をする
 # -I: rebaseの "-i" オプションから
 # -F: commitの "--fixup" オプションから
+# -C: cherry-pickのC. 選択commitを現在ブランチへ
+# -K: kill. このcommitだけを drop (後続を %(commit)^ へ付け替える. conflict時はエディタへ)
+# -< / >: 選択commitへ reset --soft / --hard (status の `<` の任意commit版)
 bind main ! ?git revert %(commit)
 bind main I ?git rebase -i %(commit)
 bind main F ?git commit --fixup %(commit)
+bind main C ?git cherry-pick %(commit)
+bind main K ?git rebase --onto %(commit)^ %(commit)
+bind main <LessThan>    ?git reset --soft %(commit)
+bind main <GreaterThan> ?git reset --hard %(commit)
 
 # status view: 作業中のメインview. 最も多く利用する
 bind status P ?git push %(remote) %(repo:head)
 bind status <Ctrl-p> ?git push --force-with-lease %(remote) %(repo:head)
 bind status + !git commit --amend
+bind status A !git commit --amend --no-edit
 bind status E !git commit --allow-empty
 bind status <LessThan> ?git reset --soft HEAD^ # LessThan: <
 bind status <Ctrl-r> ?gh pr create --web --assignee "@me"
@@ -38,9 +46,13 @@ bind refs + ?git rebase %(branch)
 # - S: stashのS. このためにgenericに割り当てられた `S` を無効化した
 # - U: `-u(--include-untracked)` のU
 # - P: popのP
+# - a: applyのa. pop と違い stash を消さずに展開する
+# - D: dropのD. stash を破棄する
 bind stash S !git stash push
 bind stash U !git stash push -u
 bind stash P !git stash pop %(stash)
+bind stash a !git stash apply %(stash)
+bind stash D ?git stash drop %(stash)
 
 # カーソル行の色を変更
 # [文字色] [背景色] [属性]


### PR DESCRIPTION
## 概要
tig に edit 系操作とコピー系のキーバインドを追加する。

## 追加したバインド
| view | key | 操作 |
|---|---|---|
| main | `C` | cherry-pick（現在ブランチへ） |
| main | `K` | このコミットだけ drop（`rebase --onto %(commit)^ %(commit)`） |
| main | `<` / `>` | 選択コミットへ reset --soft / --hard |
| status | `A` | `commit --amend --no-edit`（メッセージ据え置き） |
| stash | `a` / `D` | stash apply / drop |
| generic | `` ` `` | 選択コミットのハッシュを pbcopy |
| refs | `` ` `` | 選択ブランチ名を pbcopy |

破壊的操作（`K`, `>`, `<`, `D`）は `?`（実行前確認）付き、非破壊の `A`/`a` は即実行。

## コピーの feedback
- commit コピー（generic）は `+` プレフィックスでステータスラインに `Copied commit: <hash>` を表示。
- ただし **refs/status view は外部コマンドから戻ると view が reload され**、ステータスライン表示が消える。
  refs のブランチ名コピーは feedback なし（コピー自体は動作）。
  - ベルや `tmux display-message` も検討したが、端末/tmux 依存で不安定なため見送り。